### PR TITLE
Increase deploy job timeout to 25 minutes

### DIFF
--- a/.github/workflows/api-deploy.yml
+++ b/.github/workflows/api-deploy.yml
@@ -12,6 +12,7 @@
    api-ssh-deploy:
      name: Production
      runs-on: ubuntu-latest
+     timeout-minutes: 25
 
      steps:
        - uses: actions/checkout@v4


### PR DESCRIPTION
Add `timeout-minutes: 25` to the Production `api-ssh-deploy` job in .github/workflows/api-deploy.yml to prevent long-running deployments from being terminated prematurely. No other steps or job configuration were changed.