### PR TITLE
Bump react to v19.2.7

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -35,7 +35,7 @@
         "next-seo": "^7.2.0",
         "next-themes": "^0.4.6",
         "nextjs-progressbar": "^0.0.16",
-        "react": "^19.2.6",
+        "react": "^19.2.7",
         "react-dom": "^19.2.6",
         "react-i18next": "^17.0.7",
         "react-redux": "^9.2.0",

--- a/client/package.json
+++ b/client/package.json
@@ -36,7 +36,7 @@
         "next-themes": "^0.4.6",
         "nextjs-progressbar": "^0.0.16",
         "react": "^19.2.7",
-        "react-dom": "^19.2.6",
+        "react-dom": "^19.2.7",
         "react-i18next": "^17.0.7",
         "react-redux": "^9.2.0",
         "sharp": "^0.34.5",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -6971,10 +6971,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react@npm:^19.2.6":
-  version: 19.2.6
-  resolution: "react@npm:19.2.6"
-  checksum: 10c0/66afde33b9a9ee87b1e1cae39d8e7e040d1262e719524fd70660c4d4ce79929c532ac19fc3df5a911edaf02768fdf2c49de4ede1ba99bc6aad72796e0e26e798
+"react@npm:^19.2.7":
+  version: 19.2.7
+  resolution: "react@npm:19.2.7"
+  checksum: 10c0/0bd0e2f1bbd4ba97561c6597bf8a5fec05e6476fe61e165c1065598d16668efc6715205599c94d3ddd49d36cb0f21cbf1b9bcc18ee840b805ce222c3e8d558ac
   languageName: node
   linkType: hard
 
@@ -8428,7 +8428,7 @@ __metadata:
     next-themes: "npm:^0.4.6"
     nextjs-progressbar: "npm:^0.0.16"
     prettier: "npm:^3.8.3"
-    react: "npm:^19.2.6"
+    react: "npm:^19.2.7"
     react-dom: "npm:^19.2.6"
     react-i18next: "npm:^17.0.7"
     react-redux: "npm:^9.2.0"

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -6884,14 +6884,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-dom@npm:^19.2.6":
-  version: 19.2.6
-  resolution: "react-dom@npm:19.2.6"
+"react-dom@npm:^19.2.7":
+  version: 19.2.7
+  resolution: "react-dom@npm:19.2.7"
   dependencies:
     scheduler: "npm:^0.27.0"
   peerDependencies:
-    react: ^19.2.6
-  checksum: 10c0/dbf2aef67857c03a612bc9316a4562e5066f43fa04bf28f7f0734963fc1350da2c9f8eb973930655453281079f30cc8222bab383dbec4b5097084e2c081e3334
+    react: ^19.2.7
+  checksum: 10c0/970ff600f6e80d47d39e2f226f12f226173b3cba3382efc97c5f0cd663de9af38c7a4c11c213fb936094faeac83060d660247accaa96b752180d5b951b9cfecb
   languageName: node
   linkType: hard
 
@@ -8429,7 +8429,7 @@ __metadata:
     nextjs-progressbar: "npm:^0.0.16"
     prettier: "npm:^3.8.3"
     react: "npm:^19.2.7"
-    react-dom: "npm:^19.2.6"
+    react-dom: "npm:^19.2.7"
     react-i18next: "npm:^17.0.7"
     react-redux: "npm:^9.2.0"
     redux-mock-store: "npm:^1.5.5"


### PR DESCRIPTION
Upgrade react from ^19.2.6 to ^19.2.7 in client/package.json and update client/yarn.lock to reflect the new resolved version. This is a patch bump for React; no other dependency changes were made.