### PR TITLE
Bump react-redux to ^9.3.0

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -38,7 +38,7 @@
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "react-i18next": "^17.0.7",
-        "react-redux": "^9.2.0",
+        "react-redux": "^9.3.0",
         "sharp": "^0.34.5",
         "simple-react-ui-kit": "^1.8.6"
     },

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -6945,9 +6945,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-redux@npm:^9.2.0":
-  version: 9.2.0
-  resolution: "react-redux@npm:9.2.0"
+"react-redux@npm:^9.3.0":
+  version: 9.3.0
+  resolution: "react-redux@npm:9.3.0"
   dependencies:
     "@types/use-sync-external-store": "npm:^0.0.6"
     use-sync-external-store: "npm:^1.4.0"
@@ -6960,7 +6960,7 @@ __metadata:
       optional: true
     redux:
       optional: true
-  checksum: 10c0/00d485f9d9219ca1507b4d30dde5f6ff8fb68ba642458f742e0ec83af052f89e65cd668249b99299e1053cc6ad3d2d8ac6cb89e2f70d2ac5585ae0d7fa0ef259
+  checksum: 10c0/b9f4efcfbfbc90cac9d1709ab3affb1e18a9dc9bd3cceda43bd2e1d9d2394ee0c29df36ec2202d52b566db774888b594c8c5aa86b64f27ef34fca607c687c9e3
   languageName: node
   linkType: hard
 
@@ -8431,7 +8431,7 @@ __metadata:
     react: "npm:^19.2.7"
     react-dom: "npm:^19.2.7"
     react-i18next: "npm:^17.0.7"
-    react-redux: "npm:^9.2.0"
+    react-redux: "npm:^9.3.0"
     redux-mock-store: "npm:^1.5.5"
     sass: "npm:^1.99.0"
     schema-dts: "npm:^2.0.0"


### PR DESCRIPTION
Update react-redux dependency from ^9.2.0 to ^9.3.0 in client/package.json and update corresponding entries in client/yarn.lock so the lockfile matches the new version. This is a minor dependency bump; no source code changes included.